### PR TITLE
fix: string escape for absolute path

### DIFF
--- a/lua/image_preview/init.lua
+++ b/lua/image_preview/init.lua
@@ -46,18 +46,13 @@ function M.PreviewImage(absolutePath)
                     .. "'" .. absolutePath .. "'"
                     .. " ; pause"
             else
-                command = "silent !wezterm cli split-pane -- bash -c 'wezterm imgcat "
-                    .. absolutePath
-                    .. " ; read'"
+                command = "silent !wezterm cli split-pane -- bash -c 'wezterm imgcat \"" .. absolutePath .. "\" ; read'"
             end
         elseif term == 'kitty' then
             if vim.fn.has('win32') == 1 or vim.fn.has('win64') == 1 then
                 print('Kitty not supported on windows')
             else
-                command = 'silent !kitten @ launch --type=window kitten icat --hold '
-                    .. '\''
-                    .. absolutePath
-                    .. '\''
+                command = 'silent !kitten @ launch --type=window kitten icat --hold "' .. absolutePath .. '"'
             end
         else
             print('No support for this terminal.')


### PR DESCRIPTION
On `macOS` I did have the following issues:

- wezterm: if the path container spaces and `-` character(s) the command seen this character as command line arguments and fails with an exception,
- kitty: nothing happens when issue-ing the command `PreviewImage(absolutePath)`, even if the copied command works fine in a kitty window. Simply it does nothing in the nvim. Escaping the string surrounding the absolute path helps.

Not sure if this fix works fine with linux distros... but for macos it looks fine.